### PR TITLE
ding-libs subpackages need to be in the API

### DIFF
--- a/shared-userspace.yaml
+++ b/shared-userspace.yaml
@@ -312,7 +312,18 @@ data:
             - nfs-utils
             - libtirpc
             - libsecret
-            - ding-libs
+            - libbasicobjects
+            - libbasicobjects
+            - libcollection
+            - libcollection-devel
+            - libdhash
+            - libdhash-devel
+            - libini_config
+            - libini_config-devel
+            - libpath_utils
+            - libpath_utils-devel
+            - libref_array
+            - libref_array-devel
             - gssproxy
             - libevent
             - libnfsidmap


### PR DESCRIPTION
ding-libs has no binary package by that name.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>